### PR TITLE
Add SnapshotWithName

### DIFF
--- a/cupaloy.go
+++ b/cupaloy.go
@@ -31,6 +31,11 @@ func SnapshotT(t TestingT, i ...interface{}) {
 	Global.SnapshotT(t, i...)
 }
 
+// SnapshotWithName calls Snapshotter.SnapshotWithName with the global config.
+func SnapshotWithName(snapshotName string, i ...interface{}) error {
+	return Global.SnapshotWithName(snapshotName, i...)
+}
+
 // Snapshot compares the given variable to its previous value stored on the filesystem.
 // An error containing a diff is returned if the snapshots do not match, or if a new
 // snapshot was created.
@@ -51,6 +56,12 @@ func (c *Config) Snapshot(i ...interface{}) error {
 // appended to the function name to form the snapshot name.
 func (c *Config) SnapshotMulti(snapshotID string, i ...interface{}) error {
 	snapshotName := fmt.Sprintf("%s-%s", getNameOfCaller(), snapshotID)
+	return c.snapshot(snapshotName, i...)
+}
+
+// SnapshotWithName is similar to SnapshotMulti without appending the function name.
+// It is useful when you need full control of the snapshot filename.
+func (c *Config) SnapshotWithName(snapshotName string, i ...interface{}) error {
 	return c.snapshot(snapshotName, i...)
 }
 

--- a/examples/.snapshots/chosen-by-user
+++ b/examples/.snapshots/chosen-by-user
@@ -1,0 +1,2 @@
+Hello
+Universe!

--- a/examples/advanced_test.go
+++ b/examples/advanced_test.go
@@ -26,7 +26,7 @@ func TestRawBytes(t *testing.T) {
 	result := bytes.NewBufferString("Hello advanced world!")
 	err := cupaloy.Snapshot(result.Bytes(), result, result.String())
 	if err != nil {
-		t.Fatal("New version of snapshot format should write out certain types directly", err)
+		t.Fatal("New version of snapshot format should wNite out certain types directly", err)
 	}
 }
 
@@ -45,6 +45,14 @@ func TestConfig(t *testing.T) {
 	}
 
 	snapshotter.WithOptions(cupaloy.SnapshotSubdirectory("testdata")).SnapshotT(t, "Hello world!")
+}
+
+// SnapshotMulti allows a user to choose the full snapshot name
+func TestSnapshotMulti(t *testing.T) {
+	err := cupaloy.SnapshotWithName("chosen-by-user", "Hello", "Universe!")
+	if err != nil {
+		t.Fatalf("The config struct has all the same methods as the default %s", err)
+	}
 }
 
 // If a snapshot is updated then this returns an error


### PR DESCRIPTION
SnapshotWithName is similar to SnapshotMulti without appending the function name.
It is useful when you need full control of the snapshot filename.